### PR TITLE
Users/ersciple/m95locstrings

### DIFF
--- a/node/Strings/resources.resjson/de-de/resources.resjson
+++ b/node/Strings/resources.resjson/de-de/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "Ausnahmefehler: %s",
+  "loc.messages.LIB_FailOnCode": "Fehler beim Rückgabecode: %d",
+  "loc.messages.LIB_ReturnCode": "Rückgabecode: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "Die Ressourcendatei ist nicht vorhanden: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "Die Ressourcendatei wurde bereits festgelegt auf: %s",
+  "loc.messages.LIB_ResourceFileNotSet": "Die Ressourcendatei wurde nicht festgelegt. Die Lokalisierungszeichenfolge für den folgenden Schlüssel wurde nicht gefunden: %s",
+  "loc.messages.LIB_LocStringNotFound": "Die Lokalisierungszeichenfolge für den folgenden Schlüssel wurde nicht gefunden: %s",
+  "loc.messages.LIB_ParameterIsRequired": "\"%s\" wurde nicht angegeben.",
+  "loc.messages.LIB_InputRequired": "Eingabe erforderlich: %s",
+  "loc.messages.LIB_EndpointNotExist": "Der Endpunkt ist nicht vorhanden: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "Ungültige Endpunktauthentifizierung: %s",
+  "loc.messages.LIB_PathNotFound": "Nicht gefunden %s: %s",
+  "loc.messages.LIB_PathHasNullByte": "Der Pfad darf nicht NULL Bytes enthalten.",
+  "loc.messages.LIB_OperationFailed": "Fehler %s: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "Mehrere Arbeitsbereichübereinstimmungen. Die erste Übereinstimmung wird verwendet.",
+  "loc.messages.LIB_MergeTestResultNotSupported": "Das Mergen von Testergebnissen aus mehreren Dateien in einen Testlauf wird von dieser Version des Build-Agents für OSX/Linux nicht unterstützt. Jede Testergebnisdatei wird als separater Testlauf in VSO/TFS veröffentlicht."
+}

--- a/node/Strings/resources.resjson/es-es/resources.resjson
+++ b/node/Strings/resources.resjson/es-es/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "No controlada: %s",
+  "loc.messages.LIB_FailOnCode": "Código de retorno de error: %d",
+  "loc.messages.LIB_ReturnCode": "Código de retorno: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "El archivo de recursos no existe: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "El archivo de recursos se ha establecido ya en: %s",
+  "loc.messages.LIB_ResourceFileNotSet": "No se ha establecido el archivo de recursos. No se encuentra la cadena localizada para la clave: %s",
+  "loc.messages.LIB_LocStringNotFound": "No se encuentra la cadena localizada para la clave: %s",
+  "loc.messages.LIB_ParameterIsRequired": "No se ha proporcionado %s",
+  "loc.messages.LIB_InputRequired": "Entrada requerida: %s",
+  "loc.messages.LIB_EndpointNotExist": "No hay punto de conexión: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "Autenticación de punto de conexión no válida: %s",
+  "loc.messages.LIB_PathNotFound": "No se encuentra %s: %s",
+  "loc.messages.LIB_PathHasNullByte": "La ruta de acceso no puede tener bytes nulos",
+  "loc.messages.LIB_OperationFailed": "Error de %s: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "Hay varias coincidencias en el área de trabajo. Se usará la primera.",
+  "loc.messages.LIB_MergeTestResultNotSupported": "Esta versión del agente de compilación para OSX/Linux no admite la fusión mediante combinación de resultados de pruebas de varios archivos en una serie de pruebas. Cada archivo de resultados de pruebas se publicará como una serie de pruebas diferente en VSO/TFS."
+}

--- a/node/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/node/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "Non géré : %s",
+  "loc.messages.LIB_FailOnCode": "Code de retour de l'échec : %d",
+  "loc.messages.LIB_ReturnCode": "Code de retour : %d",
+  "loc.messages.LIB_ResourceFileNotExist": "Le fichier de ressources n'existe pas : %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "Le fichier de ressources est déjà défini : %s",
+  "loc.messages.LIB_ResourceFileNotSet": "Le fichier de ressources n'est pas défini. La chaîne localisée de la clé est introuvable : %s",
+  "loc.messages.LIB_LocStringNotFound": "Chaîne localisée introuvable pour la clé : %s",
+  "loc.messages.LIB_ParameterIsRequired": "%s non fourni",
+  "loc.messages.LIB_InputRequired": "Entrée nécessaire : %s",
+  "loc.messages.LIB_EndpointNotExist": "Point de terminaison absent : %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "Authentification du point de terminaison non valide : %s",
+  "loc.messages.LIB_PathNotFound": "%s : %s introuvable",
+  "loc.messages.LIB_PathHasNullByte": "Le chemin ne peut pas contenir d'octets de valeur Null",
+  "loc.messages.LIB_OperationFailed": "Échec de %s : %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "Plusieurs espaces de travail correspondants. Utilisation du premier d'entre eux.",
+  "loc.messages.LIB_MergeTestResultNotSupported": "La fusion des résultats des tests de plusieurs fichiers en une seule série de tests n'est pas prise en charge dans cette version de l'agent de build pour OSX/Linux. Chaque fichier de résultats des tests est publié en tant que série de tests distincte dans VSO/TFS."
+}

--- a/node/Strings/resources.resjson/it-IT/resources.resjson
+++ b/node/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "Eccezione non gestita: %s",
+  "loc.messages.LIB_FailOnCode": "Codice restituito dell'errore: %d",
+  "loc.messages.LIB_ReturnCode": "Codice restituito: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "Il file di risorse non esiste: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "Il file di risorse è già stato impostato su %s",
+  "loc.messages.LIB_ResourceFileNotSet": "Il file di risorse non è stato impostato. La stringa localizzata per la chiave %s non è stata trovata",
+  "loc.messages.LIB_LocStringNotFound": "La stringa localizzata per la chiave %s non è stata trovata",
+  "loc.messages.LIB_ParameterIsRequired": "Parametro %s non fornito",
+  "loc.messages.LIB_InputRequired": "Input richiesto: %s",
+  "loc.messages.LIB_EndpointNotExist": "Endpoint non presente: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "Autenticazione endpoint non valida: %s",
+  "loc.messages.LIB_PathNotFound": "Percorso %s non trovato: %s",
+  "loc.messages.LIB_PathHasNullByte": "Il percorso non può contenere byte Null",
+  "loc.messages.LIB_OperationFailed": "Operazione %s non riuscita: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "Sono presenti più corrispondenze dell'area di lavoro. Verrà usata la prima.",
+  "loc.messages.LIB_MergeTestResultNotSupported": "L'unione di più file di risultati del test in un'unica esecuzione dei test non è supportata in questa versione dell'agente di compilazione per OS X/Linux. Ogni file dei risultati del test verrà pubblicato come esecuzione dei test separata in VSO/TFS."
+}

--- a/node/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/node/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "未処理: %s",
+  "loc.messages.LIB_FailOnCode": "失敗のリターン コード: %d",
+  "loc.messages.LIB_ReturnCode": "リターン コード: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "リソース ファイルが存在しません: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "リソース ファイルは既に %s に設定されています",
+  "loc.messages.LIB_ResourceFileNotSet": "リソース ファイルが設定されておらず、キーの loc 文字列が見つかりません: %s",
+  "loc.messages.LIB_LocStringNotFound": "キーの loc 文字列が見つかりません: %s",
+  "loc.messages.LIB_ParameterIsRequired": "%s が提供されていません",
+  "loc.messages.LIB_InputRequired": "入力が必要です: %s",
+  "loc.messages.LIB_EndpointNotExist": "エンドポイントが存在しません: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "エンドポイントの権限が不十分です: %s",
+  "loc.messages.LIB_PathNotFound": "見つかりませんでした %s: %s",
+  "loc.messages.LIB_PathHasNullByte": "パスに null バイトを含めることはできません",
+  "loc.messages.LIB_OperationFailed": "失敗しました %s: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "複数のワークスペースが一致します。最初のワークスペースが使用されます。",
+  "loc.messages.LIB_MergeTestResultNotSupported": "複数のファイルからのテスト結果を 1 つのテスト実行にマージする処理は、OSX/Linux 用のビルド エージェントのこのバージョンではサポートされていません。各テスト結果ファイルが VSO/TFS で別個のテスト実行として発行されます。"
+}

--- a/node/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/node/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "처리되지 않음: %s",
+  "loc.messages.LIB_FailOnCode": "실패 반환 코드: %d",
+  "loc.messages.LIB_ReturnCode": "반환 코드: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "리소스 파일이 없음: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "리소스 파일이 이미 다음으로 설정됨: %s",
+  "loc.messages.LIB_ResourceFileNotSet": "리소스 파일이 설정되지 않았고 키에 대한 loc 문자열을 찾을 수 없음: %s",
+  "loc.messages.LIB_LocStringNotFound": "키에 대한 loc 문자열을 찾을 수 없음: %s",
+  "loc.messages.LIB_ParameterIsRequired": "%s이(가) 제공되지 않음",
+  "loc.messages.LIB_InputRequired": "입력 필요: %s",
+  "loc.messages.LIB_EndpointNotExist": "끝점이 없음: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "잘못된 끝점 인증: %s",
+  "loc.messages.LIB_PathNotFound": "%s을(를) 찾을 수 없음: %s",
+  "loc.messages.LIB_PathHasNullByte": "경로에 null 바이트를 포함할 수 없음",
+  "loc.messages.LIB_OperationFailed": "%s 실패: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "여러 작업 영역이 일치합니다. 첫 번째 작업 영역을 사용하세요.",
+  "loc.messages.LIB_MergeTestResultNotSupported": "이 OSX/Linux용 빌드 에이전트 버전에서 여러 파일의 테스트 결과를 하나의 테스트 실행으로 병합하는 것을 지원하지 않습니다. 각 테스트 결과 파일은 VSO/TFS에서 별도의 테스트 실행으로 게시됩니다."
+}

--- a/node/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/node/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "Не обработано: %s",
+  "loc.messages.LIB_FailOnCode": "Код возврата при сбое: %d.",
+  "loc.messages.LIB_ReturnCode": "Код возврата: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "Файл ресурсов не существует: %s.",
+  "loc.messages.LIB_ResourceFileAlreadySet": "Файл ресурсов уже задан: %s.",
+  "loc.messages.LIB_ResourceFileNotSet": "Файл ресурсов не задан, не удается найти локализованную строку для ключа: %s.",
+  "loc.messages.LIB_LocStringNotFound": "Не удается найти локализованную строку для ключа: %s.",
+  "loc.messages.LIB_ParameterIsRequired": "Не указан %s.",
+  "loc.messages.LIB_InputRequired": "Требуется ввести данные: %s.",
+  "loc.messages.LIB_EndpointNotExist": "Конечная точка отсутствует: %s.",
+  "loc.messages.LIB_InvalidEndpointAuth": "Недопустимая проверка подлинности конечной точки: %s.",
+  "loc.messages.LIB_PathNotFound": "Не найден %s: %s.",
+  "loc.messages.LIB_PathHasNullByte": "Путь не может содержать пустые байты.",
+  "loc.messages.LIB_OperationFailed": "Сбой %s: %s.",
+  "loc.messages.LIB_UseFirstGlobMatch": "Несколько рабочих областей совпадает, использована первая рабочая область.",
+  "loc.messages.LIB_MergeTestResultNotSupported": "Объединение результатов тестов из нескольких файлов в один тестовый запуск не поддерживается в этой версии агента сборки для OSX/Linux. Каждый файл результатов теста будет опубликован в качестве отдельного тестового запуска в VSO/TFS."
+}

--- a/node/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/node/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "未处理: %s",
+  "loc.messages.LIB_FailOnCode": "故障返回代码: %d",
+  "loc.messages.LIB_ReturnCode": "返回代码: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "资源文件不存在: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "资源文件已被设置为 %s",
+  "loc.messages.LIB_ResourceFileNotSet": "资源文件尚未设置，无法找到关键字的本地字符串: %s",
+  "loc.messages.LIB_LocStringNotFound": "无法找到关键字的本地字符串: %s",
+  "loc.messages.LIB_ParameterIsRequired": "未提供 %s",
+  "loc.messages.LIB_InputRequired": "输入必需项: %s",
+  "loc.messages.LIB_EndpointNotExist": "终结点不存在: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "终结点验证无效: %s",
+  "loc.messages.LIB_PathNotFound": "找不到 %s: %s",
+  "loc.messages.LIB_PathHasNullByte": "路径不能包含 null 字节",
+  "loc.messages.LIB_OperationFailed": "%s 失败: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "出现多个工作区匹配时，使用第一个。",
+  "loc.messages.LIB_MergeTestResultNotSupported": "此版本的 OSX/Linux 生成代理不支持来自某个测试运行的多文件合并测试结果，在 VSO/TFS 中，每个测试结果文件都将作为单独的测试运行进行发布。"
+}

--- a/node/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/node/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,0 +1,18 @@
+{
+  "loc.messages.LIB_UnhandledEx": "未經處理: %s",
+  "loc.messages.LIB_FailOnCode": "傳回程式碼失敗: %d",
+  "loc.messages.LIB_ReturnCode": "傳回程式碼: %d",
+  "loc.messages.LIB_ResourceFileNotExist": "資源檔案不存在: %s",
+  "loc.messages.LIB_ResourceFileAlreadySet": "資源檔案已設定至: %s",
+  "loc.messages.LIB_ResourceFileNotSet": "尚未設定資源檔案，找不到索引鍵的 loc 字串: %s",
+  "loc.messages.LIB_LocStringNotFound": "找不到索引鍵的 loc 字串: %s",
+  "loc.messages.LIB_ParameterIsRequired": "未提供 %s",
+  "loc.messages.LIB_InputRequired": "需要輸入內容: %s",
+  "loc.messages.LIB_EndpointNotExist": "端點不存在: %s",
+  "loc.messages.LIB_InvalidEndpointAuth": "端點驗證無效: %s",
+  "loc.messages.LIB_PathNotFound": "找不到 %s: %s",
+  "loc.messages.LIB_PathHasNullByte": "路徑不能包含 null 位元組",
+  "loc.messages.LIB_OperationFailed": "%s 失敗: %s",
+  "loc.messages.LIB_UseFirstGlobMatch": "多個工作區相符。請先使用。",
+  "loc.messages.LIB_MergeTestResultNotSupported": "OSX/Linux 的此版本組建代理程式不支援將多個檔案的測試結果合併至單一測試回合，每個測試結果檔案將作為個別測試回合在 VSO/TFS 中發行。"
+}

--- a/node/lib/task.ts
+++ b/node/lib/task.ts
@@ -153,14 +153,24 @@ function loadLocStrings(resourceFile: string, culture: string): { [key: string]:
     if (exist(resourceFile)) {
         debug('load strings from: ' + resourceFile);
         var resourceJson = require(resourceFile);
-
         if (resourceJson && resourceJson.hasOwnProperty('messages')) {
             var locResourceJson = null;
             // load up resource resjson for different culture
-            var localizedResourceFile = path.join(path.dirname(resourceFile), 'strings', 'resources.resjson', culture, 'resources.resjson');
-            if (exist(localizedResourceFile)) {
-                debug('load loc strings from: ' + localizedResourceFile);
-                locResourceJson = loadResJson(localizedResourceFile);
+            var localizedResourceFile = path.join(path.dirname(resourceFile), 'Strings', 'resources.resjson');
+            var upperCulture = culture.toUpperCase();
+            var cultures = [];
+            try { cultures = fs.readdirSync(localizedResourceFile); }
+            catch(ex) { }
+            for (var i = 0 ; i < cultures.length ; i++) {
+                if (cultures[i].toUpperCase() == upperCulture) {
+                    localizedResourceFile = path.join(localizedResourceFile, cultures[i], 'resources.resjson');
+                    if (exist(localizedResourceFile)) {
+                        debug('load loc strings from: ' + localizedResourceFile);
+                        locResourceJson = loadResJson(localizedResourceFile);
+                    }
+
+                    break;
+                }
             }
 
             for (var key in resourceJson.messages) {

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "0.5.10",
+  "version": "0.5.11",
   "description": "VSTS Task SDK",
   "main": "./task.js",
   "scripts": {

--- a/node/package.json
+++ b/node/package.json
@@ -38,6 +38,6 @@
     "merge2": "^0.3.6",
     "mocha": "^2.2.5",
     "semver": "^5.1.0",
-    "typescript": "next"
+    "typescript": "1.8.0-dev.20160104"
   }
 }

--- a/node/test/tasklib.ts
+++ b/node/test/tasklib.ts
@@ -1130,13 +1130,13 @@ describe('Test vsts-task-lib', function() {
             var jsonPath = path.join(tempFolder, 'task.json');
             fs.writeFileSync(jsonPath, jsonStr);
 
-            var tempLocFolder = path.join(tempFolder, 'strings', 'resources.resjson', 'zh-CN');
+            var tempLocFolder = path.join(tempFolder, 'Strings', 'resources.resjson', 'zh-CN');
             shell.mkdir('-p', tempLocFolder);
             var locJsonStr = "{\"loc.messages.key1\" : \"loc cn-string for key 1.\", \"loc.messages.key2\" : \"loc cn-string for key %d.\", \"loc.messages.key3\" : \"loc cn-string for key %%.\"}";
             var locJsonPath = path.join(tempLocFolder, 'resources.resjson');
             fs.writeFileSync(locJsonPath, locJsonStr);
 
-            process.env['SYSTEM_CULTURE'] = 'zh-CN';
+            process.env['SYSTEM_CULTURE'] = 'ZH-cn'; // Lib should handle casing differences for culture.
 
             tl.setResourcePath(jsonPath);
 

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/de-de/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/de-de/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "Der Containerpfad wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_EndpointAuth0": "\"{0}\"-Dienstendpunkt-Anmeldeinformationen",
+  "loc.messages.PSLIB_EndpointUrl0": "\"{0}\"-Dienstendpunkt-URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Fehler beim Aufzählen von Unterverzeichnissen für den folgenden Pfad: \"{0}\"",
+  "loc.messages.PSLIB_FileNotFound0": "Die Datei wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_Input0": "\"{0}\"-Eingabe",
+  "loc.messages.PSLIB_InvalidPattern0": "Ungültiges Muster: \"{0}\"",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Der Blattpfad wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Fehler bei der Normalisierung bzw. Erweiterung des Pfads. Die Pfadlänge wurde vom Kernel32-Subsystem nicht zurückgegeben für: \"{0}\"",
+  "loc.messages.PSLIB_PathNotFound0": "Der Pfad wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "Der Prozess \"{0}\" wurde mit dem Code \"{1}\" beendet.",
+  "loc.messages.PSLIB_Required0": "Erforderlich: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Fehler beim Zeichenfolgenformat.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "Der Zeichenfolgen-Ressourcenschlüssel wurde nicht gefunden: \"{0}\".",
+  "loc.messages.PSLIB_TaskVariable0": "\"{0}\"-Taskvariable"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/es-es/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/es-es/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "No se encuentra la ruta de acceso del contenedor: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "Credenciales del punto de conexión de servicio '{0}'",
+  "loc.messages.PSLIB_EndpointUrl0": "URL del punto de conexión de servicio '{0}'",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "No se pudieron enumerar los subdirectorios de la ruta de acceso: '{0}'",
+  "loc.messages.PSLIB_FileNotFound0": "Archivo no encontrado: '{0}'",
+  "loc.messages.PSLIB_Input0": "Entrada '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Patrón no válido: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "No se encuentra la ruta de acceso de la hoja: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "No se pudo normalizar o expandir la ruta de acceso. El subsistema Kernel32 no devolvió la longitud de la ruta de acceso para: '{0}'",
+  "loc.messages.PSLIB_PathNotFound0": "No se encuentra la ruta de acceso: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "El proceso '{0}' finalizó con el código '{1}'.",
+  "loc.messages.PSLIB_Required0": "Se requiere: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Error de formato de cadena.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "No se encuentra la clave de recurso de la cadena: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "Variable de tarea '{0}'"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/fr-fr/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/fr-fr/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "Le chemin du conteneur est introuvable : '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "Informations d'identification du point de terminaison de service '{0}'",
+  "loc.messages.PSLIB_EndpointUrl0": "URL du point de terminaison de service '{0}'",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Échec de l'énumération des sous-répertoires pour le chemin : '{0}'",
+  "loc.messages.PSLIB_FileNotFound0": "Fichier introuvable : {0}.",
+  "loc.messages.PSLIB_Input0": "Entrée '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Modèle non valide : '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Le chemin feuille est introuvable : '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Échec de la normalisation/l'expansion du chemin. La longueur du chemin n'a pas été retournée par le sous-système Kernel32 pour : '{0}'",
+  "loc.messages.PSLIB_PathNotFound0": "Chemin introuvable : '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "Le processus '{0}' s'est arrêté avec le code '{1}'.",
+  "loc.messages.PSLIB_Required0": "Obligatoire : {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Échec du format de la chaîne.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "Clé de la ressource de type chaîne introuvable : '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "Variable de tâche '{0}'"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/it-IT/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/it-IT/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "Percorso del contenitore non trovato: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "Credenziali dell'endpoint servizio '{0}'",
+  "loc.messages.PSLIB_EndpointUrl0": "URL dell'endpoint servizio '{0}'",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "L'enumerazione delle sottodirectory per il percorso '{0}' non è riuscita",
+  "loc.messages.PSLIB_FileNotFound0": "File non trovato: '{0}'",
+  "loc.messages.PSLIB_Input0": "Input di '{0}'",
+  "loc.messages.PSLIB_InvalidPattern0": "Criterio non valido: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Percorso foglia non trovato: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "La normalizzazione o l'espansione del percorso non è riuscita. Il sottosistema Kernel32 non ha restituito la lunghezza del percorso per '{0}'",
+  "loc.messages.PSLIB_PathNotFound0": "Percorso non trovato: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "Il processo '{0}' è stato terminato ed è stato restituito il codice '{1}'.",
+  "loc.messages.PSLIB_Required0": "Obbligatorio: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Errore nel formato della stringa.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "La chiave della risorsa stringa non è stata trovata: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "Variabile dell'attività '{0}'"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ja-jp/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ja-jp/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "コンテナーのパスが見つかりません: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "'{0}' サービス エンドポイントの資格情報",
+  "loc.messages.PSLIB_EndpointUrl0": "'{0}' サービス エンドポイントの URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "パス '{0}' のサブディレクトリを列挙できませんでした",
+  "loc.messages.PSLIB_FileNotFound0": "ファイルが見つかりません: '{0}'",
+  "loc.messages.PSLIB_Input0": "'{0}' 入力",
+  "loc.messages.PSLIB_InvalidPattern0": "使用できないパターンです: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "リーフ パスが見つかりません: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "パスの正規化/展開に失敗しました。Kernel32 サブシステムからパス '{0}' の長さが返されませんでした",
+  "loc.messages.PSLIB_PathNotFound0": "パスが見つかりません: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "プロセス '{0}' がコード '{1}' で終了しました。",
+  "loc.messages.PSLIB_Required0": "必要: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "文字列の形式が正しくありません。",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "文字列のリソース キーが見つかりません: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "'{0}' タスク変数"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ko-KR/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ko-KR/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "컨테이너 경로를 찾을 수 없음: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "'{0}' 서비스 끝점 자격 증명",
+  "loc.messages.PSLIB_EndpointUrl0": "'{0}' 서비스 끝점 URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "경로에 대해 하위 디렉터리를 열거하지 못함: '{0}'",
+  "loc.messages.PSLIB_FileNotFound0": "{0} 파일을 찾을 수 없습니다.",
+  "loc.messages.PSLIB_Input0": "'{0}' 입력",
+  "loc.messages.PSLIB_InvalidPattern0": "잘못된 패턴: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Leaf 경로를 찾을 수 없음: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "경로 정규화/확장에 실패했습니다. 다음에 대해 Kernel32 subsystem에서 경로 길이를 반환하지 않음: '{0}'",
+  "loc.messages.PSLIB_PathNotFound0": "경로를 찾을 수 없음: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "'{1}' 코드로 '{0}' 프로세스가 종료되었습니다.",
+  "loc.messages.PSLIB_Required0": "필수: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "문자열을 포맷하지 못했습니다.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "문자열 리소스 키를 찾을 수 없음: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "'{0}' 작업 변수"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/ru-RU/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/ru-RU/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "Путь к контейнеру не найден: \"{0}\".",
+  "loc.messages.PSLIB_EndpointAuth0": "Учетные данные конечной точки службы \"{0}\"",
+  "loc.messages.PSLIB_EndpointUrl0": "URL-адрес конечной точки службы \"{0}\"",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "Сбой перечисления подкаталогов для пути: \"{0}\".",
+  "loc.messages.PSLIB_FileNotFound0": "Файл не найден: \"{0}\".",
+  "loc.messages.PSLIB_Input0": "Входные данные \"{0}\".",
+  "loc.messages.PSLIB_InvalidPattern0": "Недопустимый шаблон: \"{0}\".",
+  "loc.messages.PSLIB_LeafPathNotFound0": "Путь к конечному объекту не найден: \"{0}\".",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "Сбой нормализации и расширения пути. Длина пути не была возвращена подсистемой Kernel32 для: \"{0}\".",
+  "loc.messages.PSLIB_PathNotFound0": "Путь не найден: \"{0}\".",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "Процесс \"{0}\" завершил работу с кодом \"{1}\".",
+  "loc.messages.PSLIB_Required0": "Требуется: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "Сбой формата строки.",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "Ключ ресурса строки не найден: \"{0}\".",
+  "loc.messages.PSLIB_TaskVariable0": "Переменная задачи \"{0}\""
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/zh-CN/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/zh-CN/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "找不到容器路径:“{0}”",
+  "loc.messages.PSLIB_EndpointAuth0": "“{0}”服务终结点凭据",
+  "loc.messages.PSLIB_EndpointUrl0": "“{0}”服务终结点 URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "枚举路径的子目录失败:“{0}”",
+  "loc.messages.PSLIB_FileNotFound0": "找不到文件: {0}。",
+  "loc.messages.PSLIB_Input0": "“{0}”输入",
+  "loc.messages.PSLIB_InvalidPattern0": "无效的模式:“{0}”",
+  "loc.messages.PSLIB_LeafPathNotFound0": "找不到叶路径:“{0}”",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "路径规范化/扩展失败。路径长度不是由“{0}”的 Kernel32 子系统返回的",
+  "loc.messages.PSLIB_PathNotFound0": "找不到路径:“{0}”",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "过程“{0}”已退出，代码为“{1}”。",
+  "loc.messages.PSLIB_Required0": "必需: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "字符串格式无效。",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "找不到字符串资源关键字:“{0}”",
+  "loc.messages.PSLIB_TaskVariable0": "“{0}”任务变量"
+}

--- a/powershell/VstsTaskSdk/Strings/resources.resjson/zh-TW/resources.resjson
+++ b/powershell/VstsTaskSdk/Strings/resources.resjson/zh-TW/resources.resjson
@@ -1,0 +1,17 @@
+{
+  "loc.messages.PSLIB_ContainerPathNotFound0": "找不到容器路徑: '{0}'",
+  "loc.messages.PSLIB_EndpointAuth0": "'{0}' 服務端點認證",
+  "loc.messages.PSLIB_EndpointUrl0": "'{0}' 服務端點 URL",
+  "loc.messages.PSLIB_EnumeratingSubdirectoriesFailedForPath0": "為路徑列舉子目錄失敗: '{0}'",
+  "loc.messages.PSLIB_FileNotFound0": "找不到檔案: '{0}'",
+  "loc.messages.PSLIB_Input0": "'{0}' 輸入",
+  "loc.messages.PSLIB_InvalidPattern0": "模式無效: '{0}'",
+  "loc.messages.PSLIB_LeafPathNotFound0": "找不到分葉路徑: '{0}'",
+  "loc.messages.PSLIB_PathLengthNotReturnedFor0": "路徑正規化/展開失敗。Kernel32 子系統未傳回 '{0}' 的路徑長度",
+  "loc.messages.PSLIB_PathNotFound0": "找不到路徑: '{0}'",
+  "loc.messages.PSLIB_Process0ExitedWithCode1": "處理序 '{0}' 以返回碼 '{1}' 結束。",
+  "loc.messages.PSLIB_Required0": "必要項: {0}",
+  "loc.messages.PSLIB_StringFormatFailed": "字串格式失敗。",
+  "loc.messages.PSLIB_StringResourceKeyNotFound0": "找不到字串資源索引鍵: '{0}'",
+  "loc.messages.PSLIB_TaskVariable0": "'{0}' 工作變數"
+}

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.5.1",
+  "version": "0.5.4",
   "description": "VSTS Task SDK",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
Is the fix already in master?  If not, link the bug tracking that work.
No. I've added a linked work item to the bug.

What testing was done?
Tested E2E from an agent on a Linux box connected to a German TFS SKU.

Does this fix change the AT/DT contract?
No.

Does this fix include any database servicing changes?
No. But we might need a new servicing change to get the new tasks into TFS (if one hasn't already been created for the patch milestone). I'll open a bug and follow-up with CAT team.

Were tests added to cover this to make sure it doesn't regress?  If not, link a bug or user story tracking that work.
Yes.