### PR TITLE
Removed whitespace in build badge link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![VSO] (https://mseng.visualstudio.com/DefaultCollection/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/2553/badge)
+![VSO](https://mseng.visualstudio.com/DefaultCollection/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/2553/badge)
 # VSTS DevOps Task SDK
 
 Libraries for writing Visual Studio Team Services build and deployment tasks


### PR DESCRIPTION
badge link had a whitespace between the "]" and the "(" which prevented it from being rendered as a link in npmjs registry