### PR TITLE
Fix loading Japanese resource failed

### DIFF
--- a/powershell/VstsTaskSdk/LocalizationFunctions.ps1
+++ b/powershell/VstsTaskSdk/LocalizationFunctions.ps1
@@ -115,7 +115,7 @@ function Import-LocStrings {
     # Load the json.
     Write-Verbose "Loading resource strings from: $LiteralPath"
     $count = 0
-    if ($messages = (Get-Content -LiteralPath $LiteralPath | Out-String | ConvertFrom-Json).messages) {
+    if ($messages = (Get-Content -LiteralPath $LiteralPath -Encoding UTF8 | Out-String | ConvertFrom-Json).messages) {
         # Add each resource string to the hashtable.
         foreach ($member in (Get-Member -InputObject $messages -MemberType NoteProperty)) {
             [string]$key = $member.Name
@@ -134,7 +134,7 @@ function Import-LocStrings {
     if (Test-Path -LiteralPath $resjsonPath) {
         Write-Verbose "Loading resource strings from: $resjsonPath"
         $count = 0
-        $resjson = Get-Content -LiteralPath $resjsonPath | Out-String | ConvertFrom-Json
+        $resjson = Get-Content -LiteralPath $resjsonPath -Encoding UTF8 | Out-String | ConvertFrom-Json
         foreach ($member in (Get-Member -Name loc.messages.* -InputObject $resjson -MemberType NoteProperty)) {
             if (!($value = $resjson."$($member.Name)")) {
                 continue


### PR DESCRIPTION
Get-Content does not use UTF8 unless explicitly specified in Japanese PowerShell environment. Specify Encoding UTF8 solves loading localized resource issue.

Closes bug #62