### PR TITLE
Fix Windows which

### DIFF
--- a/node/lib/task.ts
+++ b/node/lib/task.ts
@@ -646,17 +646,17 @@ export function which(tool: string, check?: boolean): string {
 
                     var baseAttempt = attempt;
                     attempt = baseAttempt + '.exe';
-                    if (exist(attempt) && stats(attempt).isFile) {
+                    if (exist(attempt) && stats(attempt).isFile()) {
                         toolPath = attempt;
                         return;
                     }
                     attempt = baseAttempt + '.cmd';
-                    if (exist(attempt) && stats(attempt).isFile) {
+                    if (exist(attempt) && stats(attempt).isFile()) {
                         toolPath = attempt;
                         return;
                     }
                     attempt = baseAttempt + '.bat';
-                    if (exist(attempt) && stats(attempt).isFile) {
+                    if (exist(attempt) && stats(attempt).isFile()) {
                         toolPath = attempt;
                         return;
                     }
@@ -664,7 +664,7 @@ export function which(tool: string, check?: boolean): string {
             }
 
             // Command not found in Path, but the input itself is point to a file.
-            if (!toolPath && exist(tool) && stats(tool).isFile) {
+            if (!toolPath && exist(tool) && stats(tool).isFile()) {
                 toolPath = path.resolve(tool);
             }
         }


### PR DESCRIPTION
There was a bug here in which the isFile checks were not actually being called.
This led to a relatively obscure bug where if the command searched for was not found in the path, and shared a name with a folder in the current directory, that folder was returned as the value of which.
This PR fixes this issue.

That being said, the fully correct fix for this issue would be to upgrade shelljs and remove this windows specific code as shelljs has fixed the indicated bug. I have not done this here as I am unsure what the larger repercussions of that upgrade may be.

@bryanmacfarlane
