### PR TITLE
Update FindFunctions.ps1

### DIFF
--- a/powershell/VstsTaskSdk/FindFunctions.ps1
+++ b/powershell/VstsTaskSdk/FindFunctions.ps1
@@ -247,7 +247,7 @@ function Get-PathIterator {
         ForEach-Object {
             if ($_.Attributes.HasFlag([VstsTaskSdk.FS.Attributes]::Directory)) {
                 if ($IncludeDirectories) {
-                    $i_.FullName
+                    $_.FullName
                 }
             } elseif ($IncludeFiles) {
                 $_.FullName


### PR DESCRIPTION
When using the IncludeDirectories switch parameter, it would result in a null ref error in the Get-PathIterator function.  This is due to the use of a variable that doesn't exist: "$i_".  Corrected it by changing it to "$_" instead.