### PR TITLE
adding mock hooks & null check in toolrunner

### DIFF
--- a/node/lib/task.ts
+++ b/node/lib/task.ts
@@ -591,6 +591,26 @@ export function exist(path: string): boolean {
 }
 
 /**
+ * Useful for determining the host operating system.
+ * see [os.type](https://nodejs.org/api/os.html#os_os_type)
+ * 
+ * @return      the name of the operating system
+ */
+export function osType(): string {
+    return os.type();
+}
+
+/**
+ * Returns the process's current working directory.
+ * see [process.cwd](https://nodejs.org/api/process.html#process_process_cwd)
+ * 
+ * @return      the path to the current working directory of the process
+ */
+export function cwd() : string {
+    return process.cwd();
+}
+
+/**
  * Checks whether a path exists.
  * If the path does not exist, the task will fail with an error message. Execution will halt.
  * 
@@ -730,6 +750,20 @@ export function which(tool: string, check?: boolean): string {
     }
     catch (err) {
         throw new Error(loc('LIB_OperationFailed', 'which', err.message));
+    }
+}
+
+/**
+ * Returns array of files in the given path, or in current directory if no path provided.  See shelljs.ls
+ * @param  {string}   options  Available options: -R (recursive), -A (all files, include files beginning with ., except for . and ..)
+ * @param  {string[]} paths    Paths to search.
+ * @return {string[]}          An array of files in the given path(s).
+ */
+export function ls(options: string, paths: string[]): string[] {
+    if(options){
+        return shell.ls(options, paths);
+    } else {
+        return shell.ls(paths);
     }
 }
 

--- a/node/lib/toolrunner.ts
+++ b/node/lib/toolrunner.ts
@@ -367,6 +367,7 @@ export class ToolRunner extends events.EventEmitter {
         }
         
         var r = child.spawnSync(this.toolPath, this.args, { cwd: ops.cwd, env: ops.env });
+        
         if (r.stdout && r.stdout.length > 0) {
             ops.outStream.write(r.stdout);
         }
@@ -376,8 +377,8 @@ export class ToolRunner extends events.EventEmitter {
         }
 
         var res:IExecResult = <IExecResult>{ code: r.status, error: r.error };
-        res.stdout = r.stdout.toString();
-        res.stderr = r.stderr.toString();
+        res.stdout = (r.stdout) ? r.stdout.toString() : null;
+        res.stderr = (r.stderr) ? r.stderr.toString() : null;
         return res;
     }   
 }


### PR DESCRIPTION
Need to expose the following methods in task so I can mock them in L0 tests in vsts-tasks

process.cwd(): string;
os.type(): string;
fs.readdirSync(path: string): string[];

Also adding a null check in tool runner so if the tool is not kicked off properly and results in no stdout or stderr, node doesn't just die but instead bubbles up a failure to the offending task.