### PR TITLE
to avoid minimatch warn

### DIFF
--- a/node/gulpfile.js
+++ b/node/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task('copy:d.ts', ['clean'], function () {
 });
 
 gulp.task('definitions', ['copy:d.ts', 'copy:manifest'], function () {
-    return dtsgen.generate({
+    return dtsgen.default({
         name: 'vsts-task-lib',
         baseDir: 'lib',
         files: [ 'task.ts', 'taskcommand.ts', 'toolrunner.ts' ],

--- a/node/package.json
+++ b/node/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "del": "^1.2.0",
-    "dts-generator": "1.5.0",
+    "dts-generator": "1.7.0",
     "gulp": "^3.9.0",
     "gulp-mocha": "2.0.0",
     "gulp-typescript": "^2.9.0",


### PR DESCRIPTION
"dts-generator" is fixed, but there are still the following dependencies that pull in old version of minimatch, logged issues there
https://github.com/gulpjs/gulp/issues/1716
https://github.com/mochajs/mocha/issues/2363
https://github.com/sindresorhus/gulp-mocha/issues/135

am gonna hold off, we get nothing by updating dts-generator, we have to wait for other dependencies to react.