### PR TITLE
Fix issue in generating Command for boolean values

### DIFF
--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -31,7 +31,7 @@ export class TaskCommand {
             for (var key in this.properties) {
                 if (this.properties.hasOwnProperty(key)) {
                     var val = this.properties[key];
-                    if (val) {
+                    if (val != null) {
                         cmdStr += key + '=' + val + ';';
                     }                    
                 }

--- a/node/test/tasklib.ts
+++ b/node/test/tasklib.ts
@@ -803,6 +803,20 @@ describe('Test vsts-task-lib', function () {
             assert.equal(tc.toString(), '##vso[some.cmd]a message');
             done();
         })
+        it('handles boolean properties', function (done) {
+            this.timeout(1000);
+
+            var tc = new tcm.TaskCommand('some.cmd', { foo: false }, 'a message');
+            assert.equal(tc.toString(), '##vso[some.cmd foo=false;]a message');
+            done();
+        })
+        it('handles undefined properties', function (done) {
+            this.timeout(1000);
+
+            var tc = new tcm.TaskCommand('some.cmd', { foo: undefined }, 'a message');
+            assert.equal(tc.toString(), '##vso[some.cmd ]a message');
+            done();
+        })
         it('parses cmd with no properties', function (done) {
             var cmdStr = '##vso[basic.command]messageVal';
 


### PR DESCRIPTION
if(val) falsify the boolean parameters. 
We should not send command only for undefined/null types