### PR TITLE
Fix find.

### DIFF
--- a/node/docs/releases.md
+++ b/node/docs/releases.md
@@ -4,6 +4,8 @@
  * Updated `setVariable` to expose an optional boolean parameter `secret`.
  * Added `getVariables` to get an array of all variables, secret and non-secret.
  * Updated `mkdirP` to improve error messages.
+ * Updated `find` to expose options whether to follow symlinks.
+ * Updated `match` to provide an overload that accepts an array of patterns.
 
 ## 0.9.5
  * API clean up as we approach 1.0 major version

--- a/node/docs/vsts-task-lib.md
+++ b/node/docs/vsts-task-lib.md
@@ -59,6 +59,7 @@ import tl = require('vsts-task-lib/task')
 <a href="#taskcp">cp</a> <br/>
 <a href="#taskmv">mv</a> <br/>
 <a href="#taskmkdirP">mkdirP</a> <br/>
+<a href="#taskFindOptions">FindOptions</a> <br/>
 <a href="#taskfind">find</a> <br/>
 <a href="#taskrmRF">rmRF</a> <br/>
 <a href="#taskpushd">pushd</a> <br/>
@@ -541,17 +542,29 @@ Param | Type | Description
 p | any | path to create
  
 <br/>
+<div id="taskFindOptions">
+### task.FindOptions <a href="#index">(^)</a>
+Interface for FindOptions
+Contains properties to control whether to follow symlinks
+ 
+Property | Description
+--- | ---
+followSpecifiedSymbolicLink | Equivalent to the -H command line option. Indicates whether to traverse descendants if the specified path is a symbolic link directory. Does not cause nested symbolic link directories to be traversed.
+followSymbolicLinks | Equivalent to the -L command line option. Indicates whether to traverse descendants of symbolic link directories.
+ 
+<br/>
 <div id="taskfind">
 ### task.find <a href="#index">(^)</a>
 Find all files under a give path
-Returns an array of full paths
+Returns an array of paths
 ```javascript
-find(findPath:string):string
+find(findPath:string, options?:FindOptions):string
 ```
  
 Param | Type | Description
 --- | --- | ---
 findPath | string | path to find files under
+options | FindOptions | options to control whether to follow symlinks
  
 <br/>
 <div id="taskrmRF">


### PR DESCRIPTION
- [x] I need to do more manual testing with `rm -f` to make sure it's going to suffice for what I need from the Delete Files task. It needs to handle deleting symlink folders/files (i.e. delete the symlink only, not the actual folder/file). It also needs to handle deleting a symlink if the target folder/file no longer exists.
 - Nevermind. I'm going to use `rm -rf` for delete files. It removes a symlink without following. I added unit tests to verify.
- [x] Add unit tests for the minimatch interface change. Madhuri pointed out to me that multiple tasks have a lot of code doing the same thing: applying match patterns. I added an overload so `pattern` can either be a string or an array of strings. I moved the hash table logic (which is used to avoid returning duplicate results) into the lib function.
- [ ] I'm on the fence about this one, but I'm leaning toward switching the find function to the following interface: `find(findPath: string)` and an overload `find(options: string, findPath: string)`. That would make it consistent with the shelljs function interfaces. Then instead of passing a dictionary of options, it would just be a string, e.g. `find('-L', '/some/path')`.