### PR TITLE
Fix spaces on Windows in cmd and args

### DIFF
--- a/node/test/scripts/path with spaces/check-arg.cmd
+++ b/node/test/scripts/path with spaces/check-arg.cmd
@@ -1,0 +1,9 @@
+@echo off
+
+rem Exit with code 0 only if there is exactly one argument
+echo %1
+
+set argCount=0
+for %%x in (%*) do set /a argCount+=1
+if %argCount%==1 exit /b 0
+exit /b 1

--- a/node/test/scripts/path with spaces/check-arg.sh
+++ b/node/test/scripts/path with spaces/check-arg.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+echo $1
+
+# Exit with code 0 only if there is exactly one argument
+if test $# -eq 1; then
+  exit 0
+else
+  exit 1
+fi

--- a/node/test/tasklib.ts
+++ b/node/test/tasklib.ts
@@ -1591,7 +1591,7 @@ describe('Test vsts-task-lib', function () {
             assert.equal(node.args.length, 5, 'should have 5 args');
             assert.equal(node.args.toString(), 'one,two,three,four,five', 'should be one,two,three,four,five');
             done();
-        })        
+        })
         it('handles padded spaces', function (done) {
             this.timeout(1000);
 
@@ -1671,6 +1671,56 @@ describe('Test vsts-task-lib', function () {
             assert.equal(node.args.toString(), '--path,/bin/working folder1', 'should be --path /bin/working folder1');
             done();
         })
+        it('handles spaces in toolPath and arguments', function () {
+            this.timeout(1000);
+
+            var toolName = os.type().match(/^Win/) ? 'check-arg.cmd' : 'check-arg.sh';
+            var tool = tl.tool(path.join(__dirname, 'scripts', 'path with spaces', toolName));
+            tool.arg('arg with spaces');
+
+            var _testExecOptions: trm.IExecOptions = {
+                cwd: __dirname,
+                env: {},
+                silent: false,
+                failOnStdErr: false,
+                ignoreReturnCode: false,
+                outStream: _nullTestStream,
+                errStream: _nullTestStream
+            }
+
+            return tool.exec(_testExecOptions)
+                .then(function (code) {
+                    assert.equal(code, 0, 'return code of script should be 0');
+                })
+                .fail(function (err) {
+                    assert.fail('script failed to run: ' + err.message);
+                });
+        })
+        if (os.type().match(/^Win/)) {
+            it('handles spaces in toolPath for Windows exe', function () {
+                this.timeout(1000);
+
+                var toolDir = path.join(__dirname, 'scripts', 'path with spaces');
+                var toolPath = path.join(toolDir, 'cmd.exe');
+                tl.cp(tl.which('cmd'), toolDir);
+
+                var cmd = tl.tool(toolPath);
+                cmd.arg(['/c', 'echo hello']);
+                return cmd.exec({
+                    cwd: __dirname,
+                    env: {},
+                    silent: false,
+                    failOnStdErr: false,
+                    ignoreReturnCode: false,
+                    outStream: _nullTestStream,
+                    errStream: _nullTestStream
+                }).then(function (code) {
+                    assert.equal(code, 0, 'return code of command should be 0');
+                }).fail(function (err) {
+                    assert.fail('command failed to run: ' + err.message);
+                });
+            })
+        }
     });
 
     describe('Codecoverage commands', function () {

--- a/node/toolrunner.ts
+++ b/node/toolrunner.ts
@@ -230,7 +230,7 @@ export class ToolRunner extends events.EventEmitter {
         var runSettings;
         if (os.type().match(/^Win/)) {
             runSettings = {
-                shell: this.toolPath.indexOf(' ') !== -1, //this.toolPath.endsWith('.cmd') || this.toolPath.endsWith('.bat'),
+                shell: this.toolPath.indexOf(' ') !== -1,
                 toolPath: this.toolPath.indexOf(' ') === -1 ? this.toolPath : '"' + this.toolPath + '"',
                 args: this.args.map((arg: string) => /^[^"].* .*[^"]$/.test(arg) ? '"' + arg + '"' : arg)
             }


### PR DESCRIPTION
Only as a suggestion for #112.

Note: I had to increase the timeouts on Windows, but left them as-is because this probably works better on your end.

Also, it took me a while to realise this, but node.js tasks run in an embedded node, which at this time is 5.10.1. Quoting `toolName` does not work on node 4.4.7.

And apologies for the whitespace changes, default editor settings...
