### PR TITLE
Update README.md

### DIFF
--- a/node/README.md
+++ b/node/README.md
@@ -29,7 +29,6 @@ Once:
 ```bash
 $ cd node
 $ npm install
-$ sudo npm install tsc -g
 ```
 
 Build and Test:


### PR DESCRIPTION
Since typescript is already a dev dependency, I believe npm test will use the tsc in the path under ./node_modules/.bin/tsc, which is a symlink to ../typescript/bin/tsc
