### PR TITLE
Allowing unmocked filters to use the base behavior

### DIFF
--- a/node/mock-task.ts
+++ b/node/mock-task.ts
@@ -407,11 +407,13 @@ export function matchFile(list, pattern, options): string[] {
     return mock.getResponse('match', pattern) || [];
 }
 
-export function filter(pattern, options): any {
-    var filterList = mock.getResponse('filter', pattern) || [];
-	return function(pattern, i, arr) {
-		return filterList.indexOf(pattern) >= 0;
-	}
+export function filter(pattern, options): (element: string, index: number, array: string[]) => boolean {
+    var filterList: string[] = mock.getResponse('filter', pattern);
+    if (filterList) {
+        return (element, index, array) => (filterList.indexOf(element) !== -1);
+    }
+    // default back to the built-in behavior
+    return task.filter(pattern, options);
 }
 
 //-----------------------------------------------------

--- a/node/task.ts
+++ b/node/task.ts
@@ -1295,7 +1295,7 @@ export function match(list: string[], pattern: any, options?: MatchOptions): str
     return list.filter((item: string) => map.hasOwnProperty(item));
 }
 
-export function filter(pattern: string, options?: MatchOptions): (element: string, indexed: number, array: string[]) => boolean {
+export function filter(pattern: string, options?: MatchOptions): (element: string, index: number, array: string[]) => boolean {
     return minimatch.filter(pattern, options);
 }
 

--- a/node/test/mocktests.ts
+++ b/node/test/mocktests.ts
@@ -146,5 +146,42 @@ describe('Mock Tests', function () {
         
         assert(tool, "tool should not be null");
         assert(rc == 0, "rc is 0");
-    })                
+    })
+
+    it('Unmocked filter returns underlying task behavior', (done) => {
+        var a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{};
+
+        mt.setAnswers(a);
+
+        let filter = mt.filter("*ab*", null);
+
+        let filteredValues = ["cat", "lab", "foo"].filter(filter);
+
+        assert.equal(filteredValues.length, 1);
+        assert.equal(filteredValues[0], "lab");
+
+        done();
+    })
+
+    it('Mocked filter returns true for mocked paths', (done) => {
+        let paths = [
+            'C:\\path\\foo.txt',
+            'C:\\path\\foo.exe',
+            'C:\\path\\foo.exe.config',
+        ];
+        let a: ma.TaskLibAnswers = <ma.TaskLibAnswers>{
+            filter: {
+                '*.exe': ['C:\\path\\foo.exe']
+            }
+        };
+        mt.setAnswers(a);
+
+        let filter = mt.filter("*.exe", null);
+        let filteredPaths = paths.filter(filter);
+
+        assert.equal(filteredPaths.length, 1);
+        assert.equal(filteredPaths[0], 'C:\\path\\foo.exe');
+
+        done();
+    })
 });


### PR DESCRIPTION
If you don't mock a filter, then calls to task.filter returns a function that doesn't match anything. This change ensures that an un-mocked filter returns the base behavior.