### PR TITLE
Fix String.prototype.EndsWith to be ES6 compliance

### DIFF
--- a/node/extensions.ts
+++ b/node/extensions.ts
@@ -1,6 +1,6 @@
 interface String {
    startsWith(str): boolean;
-   endsWith(str): boolean;
+   endsWith(str: string, pos?: number): boolean;
    isEqual(ignoreCase, str): boolean;
    replaceVars(vars): string;
 }
@@ -9,8 +9,17 @@ String.prototype.startsWith = function (str) {
     return this.slice(0, str.length) == str;
 }
 
-String.prototype.endsWith = function (str) {
-    return this.slice(-str.length) == str;
+// ES6 compliance polyfill 
+if (!String.prototype.endsWith) {
+  String.prototype.endsWith = function(searchString, position) {
+      var subjectString = this.toString();
+      if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) {
+        position = subjectString.length;
+      }
+      position -= searchString.length;
+      var lastIndex = subjectString.lastIndexOf(searchString, position);
+      return lastIndex !== -1 && lastIndex === position;
+  };
 }
 
 String.prototype.isEqual = function(ignoreCase, str) {


### PR DESCRIPTION
Fix the String.prototype.endsWith polyfill to unblock the issue with Node unable to complete TLS handshake. 