### PR TITLE
Add escaping of closing bracket character

### DIFF
--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "VSTS Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -43,7 +43,7 @@ export class TaskCommand {
         // safely append the message - avoid blowing up when attempting to
         // call .replace() if message is not a string for some reason
         let message: string = '' + (this.message || '');
-        cmdStr += escape(message);
+        cmdStr += escapedata(message);
 
         return cmdStr;
     }
@@ -83,9 +83,19 @@ export function commandFromString(commandLine) {
         });
     }
 
-    let msg: string = unescape(commandLine.substring(rbPos + 1));
+    let msg: string = unescapedata(commandLine.substring(rbPos + 1));
     var cmd = new TaskCommand(command, properties, msg);
     return cmd;
+}
+
+function escapedata(s) : string {
+    return s.replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A');
+}
+
+function unescapedata(s) : string {
+    return s.replace(/%0D/g, '\r')
+            .replace(/%0A/g, '\n');
 }
 
 function escape(s) : string {

--- a/node/taskcommand.ts
+++ b/node/taskcommand.ts
@@ -32,7 +32,7 @@ export class TaskCommand {
                 if (this.properties.hasOwnProperty(key)) {
                     var val = this.properties[key];
                     if (val) {
-                        cmdStr += key + '=' + val + ';';
+                        cmdStr += key + '=' + escape(val) + ';';
                     }
                 }
             }
@@ -43,7 +43,7 @@ export class TaskCommand {
         // safely append the message - avoid blowing up when attempting to
         // call .replace() if message is not a string for some reason
         let message: string = '' + (this.message || '');
-        cmdStr += message.replace(/\r/g, '%0D').replace(/\n/g, '%0A');
+        cmdStr += escape(message);
 
         return cmdStr;
     }
@@ -66,22 +66,38 @@ export function commandFromString(commandLine) {
         command = cmdInfo.trim().substring(0, spaceIdx);
         var propSection = cmdInfo.trim().substring(spaceIdx+1);
 
-        var propLines = propSection.split(';');
-        propLines.forEach(function (propLine) {
+        var propLines: string[] = propSection.split(';');
+        propLines.forEach(function (propLine: string) {
             propLine = propLine.trim();
             if (propLine.length > 0) {
-                var propParts = propLine.split('=');
-                if (propParts.length != 2) {
+                var eqIndex = propLine.indexOf('=');
+                if (eqIndex == -1){
                     throw new Error('Invalid property: ' + propLine);
                 }
-                properties[propParts[0]] = propParts[1];
+
+                var key: string = propLine.substring(0, eqIndex);
+                var val: string = propLine.substring(eqIndex+1);
+
+                properties[key] = unescape(val);
             }
         });
     }
 
-    var msg = commandLine.substring(rbPos + 1)
-        .replace(/%0D/g, '\r')
-        .replace(/%0A/g, '\n');
+    let msg: string = unescape(commandLine.substring(rbPos + 1));
     var cmd = new TaskCommand(command, properties, msg);
     return cmd;
+}
+
+function escape(s) : string {
+    return s.replace(/\r/g, '%0D')
+            .replace(/\n/g, '%0A')
+            .replace(/]/g, '%5D')
+            .replace(/;/g, '%3B');
+}
+
+function unescape(s) : string {
+    return s.replace(/%0D/g, '\r')
+            .replace(/%0A/g, '\n')
+            .replace(/%5D/g, ']')
+            .replace(/%3B/g, ';');
 }

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -46,11 +46,15 @@ describe('Command Tests', function () {
     it('toString escapes message', function (done) {
         this.timeout(1000);
 
-        var tc = new tcm.TaskCommand('some.cmd', { foo: 'bar' }, 'cr \r lf \n crlf \r\n eom');
+        var tc = new tcm.TaskCommand('some.cmd', { foo: 'bar' }, 'cr \r lf \n crlf \r\n eom ]');
         assert(tc, 'TaskCommand constructor works');
         var cmdStr = tc.toString();
-        assert.equal(cmdStr, '##vso[some.cmd foo=bar;]cr %0D lf %0A crlf %0D%0A eom');
+        assert.equal(cmdStr, '##vso[some.cmd foo=bar;]cr %0D lf %0A crlf %0D%0A eom %5D');
         done();
+    })
+    it ('toString escapes properties', function (done) {
+        // TODO: Implement.
+        assert.fail();
     })
     it('handles null properties', function (done) {
         this.timeout(1000);
@@ -105,12 +109,16 @@ describe('Command Tests', function () {
         done();
     })
     it('parses and unescapes message', function (done) {
-        var cmdStr = '##vso[basic.command]cr %0D lf %0A crlf %0D%0A eom';
+        var cmdStr = '##vso[basic.command]cr %0D lf %0A crlf %0D%0A eom %5D';
 
         var tc = tcm.commandFromString(cmdStr);
         assert.equal(tc.command, 'basic.command', 'cmd should be basic.command');
-        assert.equal(tc.message, 'cr \r lf \n crlf \r\n eom');
+        assert.equal(tc.message, 'cr \r lf \n crlf \r\n eom ]');
         done();
+    })
+    it ('parses and unescapes properties', function (done) {
+        // TODO: Implement.
+        assert.fail();
     })
     it('handles empty properties', function (done) {
         this.timeout(1000);

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -48,10 +48,10 @@ describe('Command Tests', function () {
     it('toString escapes message', function (done) {
         this.timeout(1000);
 
-        var tc = new tcm.TaskCommand('some.cmd', { foo: 'bar' }, 'cr \r lf \n crlf \r\n eom ]');
+        var tc = new tcm.TaskCommand('some.cmd', { foo: 'bar' }, 'cr \r lf \n crlf \r\n eom ] ;');
         assert(tc, 'TaskCommand constructor works');
         var cmdStr = tc.toString();
-        assert.equal(cmdStr, '##vso[some.cmd foo=bar;]cr %0D lf %0A crlf %0D%0A eom %5D');
+        assert.equal(cmdStr, '##vso[some.cmd foo=bar;]cr %0D lf %0A crlf %0D%0A eom ] ;');
         done();
     })
 
@@ -123,11 +123,11 @@ describe('Command Tests', function () {
     })
 
     it('parses and unescapes message', function (done) {
-        var cmdStr = '##vso[basic.command]cr %0D lf %0A crlf %0D%0A eom %5D';
+        var cmdStr = '##vso[basic.command]cr %0D lf %0A crlf %0D%0A eom ] ;';
 
         var tc = tcm.commandFromString(cmdStr);
         assert.equal(tc.command, 'basic.command', 'cmd should be basic.command');
-        assert.equal(tc.message, 'cr \r lf \n crlf \r\n eom ]');
+        assert.equal(tc.message, 'cr \r lf \n crlf \r\n eom ] ;');
         done();
     })
 

--- a/node/test/commandtests.ts
+++ b/node/test/commandtests.ts
@@ -34,6 +34,7 @@ describe('Command Tests', function () {
 
         done();
     })
+
     it('toStrings', function (done) {
         this.timeout(1000);
 
@@ -43,6 +44,7 @@ describe('Command Tests', function () {
         assert.equal(cmdStr, '##vso[some.cmd foo=bar;]a message');
         done();
     })
+
     it('toString escapes message', function (done) {
         this.timeout(1000);
 
@@ -52,10 +54,17 @@ describe('Command Tests', function () {
         assert.equal(cmdStr, '##vso[some.cmd foo=bar;]cr %0D lf %0A crlf %0D%0A eom %5D');
         done();
     })
+
     it ('toString escapes properties', function (done) {
-        // TODO: Implement.
-        assert.fail();
+        this.timeout(1000);
+
+        var tc = new tcm.TaskCommand('some.cmd', { foo: ';=\r=\n' }, 'dog');
+        assert(tc, 'TaskCommand constructor works');
+        var cmdStr = tc.toString();
+        assert.equal(cmdStr, '##vso[some.cmd foo=%3B=%0D=%0A;]dog');
+        done();
     })
+
     it('handles null properties', function (done) {
         this.timeout(1000);
 
@@ -63,6 +72,7 @@ describe('Command Tests', function () {
         assert.equal(tc.toString(), '##vso[some.cmd]a message');
         done();
     })
+
     it('parses cmd with no properties', function (done) {
         var cmdStr = '##vso[basic.command]messageVal';
 
@@ -73,6 +83,7 @@ describe('Command Tests', function () {
         assert.equal(tc.message, 'messageVal', 'message is correct');
         done();
     })
+
     it('parses basic cmd with values', function (done) {
         var cmdStr = '##vso[basic.command prop1=val1;]messageVal';
 
@@ -85,6 +96,7 @@ describe('Command Tests', function () {
         assert.equal(tc.message, 'messageVal', 'message is correct');
         done();
     })
+
     it('parses basic cmd with multiple properties no trailing semi', function (done) {
         var cmdStr = '##vso[basic.command prop1=val1;prop2=val2]messageVal';
 
@@ -98,6 +110,7 @@ describe('Command Tests', function () {
         assert.equal(tc.message, 'messageVal', 'message is correct');
         done();
     })
+
     it('parses values with spaces in them', function (done) {
         var cmdStr = '##vso[task.setvariable variable=task variable;]task variable set value';
 
@@ -108,6 +121,7 @@ describe('Command Tests', function () {
         assert.equal(tc.message, 'task variable set value');
         done();
     })
+
     it('parses and unescapes message', function (done) {
         var cmdStr = '##vso[basic.command]cr %0D lf %0A crlf %0D%0A eom %5D';
 
@@ -116,10 +130,17 @@ describe('Command Tests', function () {
         assert.equal(tc.message, 'cr \r lf \n crlf \r\n eom ]');
         done();
     })
+
     it ('parses and unescapes properties', function (done) {
-        // TODO: Implement.
-        assert.fail();
+        var cmdStr = '##vso[basic.command foo=%3B=%0D=%0A;]dog';
+
+        var tc = tcm.commandFromString(cmdStr);
+        assert.equal(tc.command, 'basic.command', 'cmd should be basic.command');
+        assert.equal(tc.properties['foo'], ';=\r=\n', 'property should be unescaped')
+        assert.equal(tc.message, 'dog');
+        done();
     })
+
     it('handles empty properties', function (done) {
         this.timeout(1000);
 

--- a/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
+++ b/powershell/VstsTaskSdk/LoggingCommandFunctions.ps1
@@ -3,8 +3,8 @@ $script:loggingCommandEscapeMappings = @( # TODO: WHAT ABOUT "="? WHAT ABOUT "%"
     New-Object psobject -Property @{ Token = ';' ; Replacement = '%3B' }
     New-Object psobject -Property @{ Token = "`r" ; Replacement = '%0D' }
     New-Object psobject -Property @{ Token = "`n" ; Replacement = '%0A' }
+    New-Object psobject -Property @{ Token = "]" ; Replacement = '%5D' }
 )
-# TODO: BUG: Escape ]
 # TODO: BUG: Escape % ???
 # TODO: Add test to verify don't need to escape "=".
 

--- a/powershell/package.json
+++ b/powershell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-sdk",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "VSTS Task SDK",
   "scripts": {
     "build": "node make.js build",


### PR DESCRIPTION
This investigation originally started because of [this](https://github.com/Microsoft/vsts-agent/issues/1100) issue.

The code here doesn't solve that specific issue but we need it anyways. That issue will be solved by a change in DistributedTask.

This change adds escaping for ']' in the node code and ps code. We also weren't escaping the property values in the node code previously so that is added too. The Agent already unescapes property values.