### PR TITLE
Allow multiple resource files

### DIFF
--- a/node/internal.ts
+++ b/node/internal.ts
@@ -66,7 +66,6 @@ export function _setErrStream(errStream): void {
 //-----------------------------------------------------
 
 let _locStringCache: { [key: string]: string } = {};
-//let _resourceFile: string;
 let _resourceFiles: { [key: string]: string } = {};
 let _libResourceFileLoaded: boolean = false;
 let _resourceCulture: string = 'en-US';

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -66,7 +66,8 @@ export function _setErrStream(errStream): void {
 //-----------------------------------------------------
 
 let _locStringCache: { [key: string]: string } = {};
-let _resourceFile: string;
+//let _resourceFile: string;
+let _resourceFiles: { [key: string]: string } = {};
 let _libResourceFileLoaded: boolean = false;
 let _resourceCulture: string = 'en-US';
 
@@ -146,20 +147,20 @@ function _loadLocStrings(resourceFile: string, culture: string): { [key: string]
  * @returns   void
  */
 export function _setResourcePath(path: string): void {
-    if (process.env['TASKLIB_INPROC_UNITS']) {
-        _resourceFile = null;
+    if (process.env['TASKLIB_INPROC_UNITS'] && process.env['TASKLIB_INPROC_UNITS'] != '0') {
+        _resourceFiles = {};
         _libResourceFileLoaded = false;
         _locStringCache = {};
         _resourceCulture = 'en-US';
     }
 
-    if (!_resourceFile) {
+    if (!_resourceFiles[path]) {
         _checkPath(path, 'resource file path');
-        _resourceFile = path;
-        _debug('set resource file to: ' + _resourceFile);
+        _resourceFiles[path] = path;
+        _debug('adding resource file: ' + path);
 
         _resourceCulture = _getVariable('system.culture') || _resourceCulture;
-        var locStrs = _loadLocStrings(_resourceFile, _resourceCulture);
+        var locStrs: { [key: string]: string; } = _loadLocStrings(path, _resourceCulture);
         for (var key in locStrs) {
             //cache loc string
             _locStringCache[key] = locStrs[key];
@@ -167,7 +168,7 @@ export function _setResourcePath(path: string): void {
 
     }
     else {
-        _warning(_loc('LIB_ResourceFileAlreadySet', _resourceFile));
+        _warning(_loc('LIB_ResourceFileAlreadySet', path));
     }
 }
 
@@ -196,7 +197,7 @@ export function _loc(key: string, ...param: any[]): string {
         locString = _locStringCache[key];
     }
     else {
-        if (!_resourceFile) {
+        if (Object.keys(_resourceFiles).length <= 0) {
             _warning(_loc('LIB_ResourceFileNotSet', key));
         }
         else {

--- a/node/internal.ts
+++ b/node/internal.ts
@@ -146,7 +146,7 @@ function _loadLocStrings(resourceFile: string, culture: string): { [key: string]
  * @returns   void
  */
 export function _setResourcePath(path: string): void {
-    if (process.env['TASKLIB_INPROC_UNITS'] && process.env['TASKLIB_INPROC_UNITS'] != '0') {
+    if (process.env['TASKLIB_INPROC_UNITS']) {
         _resourceFiles = {};
         _libResourceFileLoaded = false;
         _locStringCache = {};

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "VSTS Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/test/loctests.ts
+++ b/node/test/loctests.ts
@@ -76,7 +76,7 @@ describe('Loc Tests', function () {
         this.timeout(1000);
 
         // Don't reset values each time we call setResourcesPath for this test.
-        process.env['TASKLIB_INPROC_UNITS'] = '0';
+        process.env['TASKLIB_INPROC_UNITS'] = '';
 
         // Arrange
         var tempFolder = path.join(testutil.getTestTemp(), 'loc-str-from-loc-res-json2');

--- a/node/test/loctests.ts
+++ b/node/test/loctests.ts
@@ -13,7 +13,7 @@ import testutil = require('./testutil');
 
 describe('Loc Tests', function () {
 
-    before(function (done) {
+    beforeEach(function (done) {
         try {
             testutil.initialize();
         }
@@ -72,6 +72,54 @@ describe('Loc Tests', function () {
 
         done();
     })
+    it('gets loc string from second loc resources.json', function (done) {
+        this.timeout(1000);
+
+        // Don't reset values each time we call setResourcesPath for this test.
+        process.env['TASKLIB_INPROC_UNITS'] = '0';
+
+        // Arrange
+        var tempFolder = path.join(testutil.getTestTemp(), 'loc-str-from-loc-res-json2');
+        shell.mkdir('-p', tempFolder);
+
+        // Create first task.json and resources file
+        var jsonStr = "{\"messages\": {\"key6\" : \"string for key 6.\"}}";
+        var jsonPath = path.join(tempFolder, 'task.json');
+        fs.writeFileSync(jsonPath, jsonStr);
+
+        var tempLocFolder = path.join(tempFolder, 'Strings', 'resources.resjson', 'zh-CN');
+        shell.mkdir('-p', tempLocFolder);
+        var locJsonStr = "{\"loc.messages.key6\" : \"loc cn-string for key 6.\"}";
+        var locJsonPath = path.join(tempLocFolder, 'resources.resjson');
+        fs.writeFileSync(locJsonPath, locJsonStr);
+
+        // Create second task.json and resources file
+        var nestedLocFolder = path.join(tempFolder, 'nested');
+        shell.mkdir('-p', nestedLocFolder);
+
+        var jsonStr2 = "{\"messages\": {\"keySecondFile\" : \"string for keySecondFile.\"}}";
+        var jsonPath2 = path.join(nestedLocFolder, 'task.json');
+        fs.writeFileSync(jsonPath2, jsonStr2);
+
+        var tempLocFolder2 = path.join(nestedLocFolder, 'Strings', 'resources.resjson', 'zh-CN');
+        shell.mkdir('-p', tempLocFolder2);
+        var locJsonStr2 = "{\"loc.messages.keySecondFile\" : \"loc cn-string for keySecondFile.\"}";
+        var locJsonPath2 = path.join(tempLocFolder2, 'resources.resjson');
+        fs.writeFileSync(locJsonPath2, locJsonStr2);
+
+        process.env['SYSTEM_CULTURE'] = 'ZH-cn'; // Lib should handle casing differences for culture.
+
+        // Act
+        tl.setResourcePath(jsonPath);
+        tl.setResourcePath(jsonPath2);
+
+        // Assert
+        assert.equal(tl.loc('key6'), 'loc cn-string for key 6.', 'string not found for key.');
+        assert.equal(tl.loc('keySecondFile'), 'loc cn-string for keySecondFile.', 'string not found for keySecondFile.');
+
+        done();
+    })
+    
     it('fallback to current string if culture resources.resjson not found', function (done) {
         this.timeout(1000);
 
@@ -142,7 +190,7 @@ describe('Loc Tests', function () {
         fs.writeFileSync(jsonPath, jsonStr);
 
         tl.setResourcePath(jsonPath);
-        assert.equal(tl.loc('key3', 3), 'key3 3', 'key and params not return for non-exist key.');
+        assert.equal(tl.loc('key9', 9), 'key9 9', 'key and params not return for non-exist key.');
 
         done();
     })

--- a/node/test/loctests.ts
+++ b/node/test/loctests.ts
@@ -190,7 +190,7 @@ describe('Loc Tests', function () {
         fs.writeFileSync(jsonPath, jsonStr);
 
         tl.setResourcePath(jsonPath);
-        assert.equal(tl.loc('key9', 9), 'key9 9', 'key and params not return for non-exist key.');
+        assert.equal(tl.loc('key3', 3), 'key3 3', 'key and params not return for non-exist key.');
 
         done();
     })


### PR DESCRIPTION
This is in reference to:

#242 Enable importing multiple resource files

I changed resource files to a dictionary for quick access, the key and value are the same (the path).