### PR TITLE
Update TaskLibAnswers to have all supported commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ Reference examples of our in the box tasks [are here](https://github.com/Microso
  * __Consistent API:__ The TypeScript and PowerShell libs are largely consistent. They only differ where it makes sense (being true to the platform).
  * __Tracing for free:__ Tracing has been built-in to many of the commands. Use the SDK and get some debug tracing for free.
 
-## Typescript Tasks  
+## TypeScript Tasks
 
-Cross platform tasks are written in Typescript.  It is the preferred way to write tasks once.
+Cross platform tasks are written in TypeScript.  It is the preferred way to write tasks once.
 
 [![NPM version][npm-lib-image]][npm-lib-url] ![VSTS](https://mseng.visualstudio.com/DefaultCollection/_apis/public/build/definitions/b924d696-3eae-4116-8443-9a18392d8544/2553/badge)
 

--- a/node/README.md
+++ b/node/README.md
@@ -7,15 +7,15 @@ Libraries for writing [Visual Studio Team Services](https://www.visualstudio.com
 
 Reference examples of our in the box tasks [are here](https://github.com/Microsoft/vsts-tasks)
 
-## Typescript Tasks  
+## TypeScript Tasks
 
-Cross platform tasks are written in Typescript.  It is the preferred way to write tasks once.
+Cross platform tasks are written in TypeScript.  It is the preferred way to write tasks once.
 
 [![NPM version][npm-lib-image]][npm-lib-url]
 
 Step by Step: [Create Task](docs/stepbystep.md)  
 
-Documentation: [Typescript API](docs/vsts-task-lib.md), [task JSON schema](https://aka.ms/vsts-tasks.schema.json)
+Documentation: [TypeScript API](docs/vsts-task-lib.md), [task JSON schema](https://aka.ms/vsts-tasks.schema.json)
 
 Guidance: [Finding Files](docs/findingfiles.md), [Minimum agent version](docs/minagent.md), [Proxy](docs/proxy.md), [Certificate](docs/cert.md)
 

--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -8,13 +8,15 @@ export interface TaskLibAnswerExecResult {
 }
 
 export interface TaskLibAnswers {
-    which?: { [key: string]: string; },
-    exec?: { [ key: string]: TaskLibAnswerExecResult },
     checkPath?: { [key: string]: boolean },
+    cwd?: { [key: string]: string },
+    exec?: { [ key: string]: TaskLibAnswerExecResult },
     exist?: { [key: string]: boolean },
     find?: { [key: string]: string[] },
     findMatch?: { [key: string]: string[] },
+    ls?: { [key: string]: string },
     rmRF?: { [key: string]: { success: boolean } },
+    which?: { [key: string]: string; },
 }
 
 export class MockAnswers {

--- a/node/mock-toolrunner.ts
+++ b/node/mock-toolrunner.ts
@@ -46,7 +46,7 @@ export interface IExecSyncResult {
 
 export function debug(message) {
     // do nothing, overridden
-};
+}
 
 export class ToolRunner extends events.EventEmitter {
     constructor(toolPath) {


### PR DESCRIPTION
These are all the commands that are looked up in `MockAnswers` in mock-task and mock-toolrunner.
With this change, we should stop using type assertions to force the `TaskLibAnswers` type when we set up the mocks for our L0 tests.
This will allow test authors to catch commands they think are being mocked but are not.