### PR TITLE
Missed a couple mocked commands.  Bump patch version

### DIFF
--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -22,7 +22,7 @@ export interface TaskLibAnswers {
 }
 
 // TODO TypeScript 2.1: use `keyof`
-export type MockedCommand = "checkPath"
+export type MockedCommand = 'checkPath'
     | 'cwd'
     | 'exec'
     | 'exist'
@@ -51,7 +51,7 @@ export class MockAnswers {
         }
 
         if (!this._answers[cmd]) {
-            debug(`no mock responses registered for given cmd`);
+            debug(`no mock responses registered for ${JSON.stringify(cmd)}`);
             return null;
         }
 

--- a/node/mock-answer.ts
+++ b/node/mock-answer.ts
@@ -21,7 +21,7 @@ export interface TaskLibAnswers {
     which?: { [key: string]: string },
 }
 
-// TODO TypeScript 2.1: use `keyof`
+// TODO TypeScript 2.1: replace with `keyof TaskLibAnswers`
 export type MockedCommand = 'checkPath'
     | 'cwd'
     | 'exec'

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "VSTS Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vsts-task-lib",
-  "version": "2.3.2",
+  "version": "2.4.0",
   "description": "VSTS Task SDK",
   "main": "./task.js",
   "typings": "./task.d.ts",


### PR DESCRIPTION
Forgot to bump the patch version before.
Noticed that I missed a couple of commands that were actually mocked, and so the previous changes were insufficient to stop coercing the `TaskLibAnswer` type in our existing code.  I defined the `MockedCommand` type here so that the compiler will catch all arguments to `getResponse`.