### PR TITLE
Adding secureFile input type in task.json scheme

### DIFF
--- a/tasks.schema.json
+++ b/tasks.schema.json
@@ -141,6 +141,7 @@
                   "multiLine",
                   "pickList",
                   "radio",
+                  "secureFile",
                   "string"
                 ]
               },


### PR DESCRIPTION
Addressing issue: https://github.com/MicrosoftDocs/vsts-docs/issues/549