### PR TITLE
Added SecureFile functions in PS SDK

### DIFF
--- a/powershell/Tests/L0/Get-SecureFileName.ps1
+++ b/powershell/Tests/L0/Get-SecureFileName.ps1
@@ -1,0 +1,17 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\lib\Initialize-Test.ps1
+$env:SECUREFILE_NAME_10 = 'securefile10.p12'
+
+Invoke-VstsTaskScript -ScriptBlock {
+    # Act.
+    $actual = Get-VstsSecureFileName -Id '10'
+
+    # Assert.
+    Assert-IsNotNullOrEmpty $actual
+    Assert-AreEqual 'securefile10.p12' $actual
+
+    Assert-IsNullOrEmpty $env:SECUREFILE_NAME_10
+}

--- a/powershell/Tests/L0/Get-SecureFileTicket.ps1
+++ b/powershell/Tests/L0/Get-SecureFileTicket.ps1
@@ -1,0 +1,15 @@
+[CmdletBinding()]
+param()
+
+# Arrange.
+. $PSScriptRoot\..\lib\Initialize-Test.ps1
+$env:SECUREFILE_TICKET_10 = 'rsaticket10'
+Invoke-VstsTaskScript -ScriptBlock {
+    # Act.
+    $actual = Get-VstsSecureFileTicket -Id '10'
+
+    # Assert.
+    Assert-IsNotNullOrEmpty $actual
+    Assert-AreEqual 'rsaticket10' $actual
+    Assert-IsNullOrEmpty $env:SECUREFILE_TICKET_10
+}

--- a/powershell/VstsTaskSdk/InputFunctions.ps1
+++ b/powershell/VstsTaskSdk/InputFunctions.ps1
@@ -66,6 +66,74 @@ function Get-Endpoint {
 
 <#
 .SYNOPSIS
+Gets a secure file ticket.
+
+.DESCRIPTION
+Gets the secure file ticket that can be used to download the secure file contents.
+
+.PARAMETER Id
+Secure file id.
+
+.PARAMETER Require
+Writes an error to the error pipeline if the ticket is not found.
+#>
+function Get-SecureFileTicket {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Id,
+        [switch]$Require)
+
+    $originalErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Stop'
+
+        $description = Get-LocString -Key PSLIB_Input0 -ArgumentList $Id
+        $key = "SECUREFILE_TICKET_$Id"
+        
+        Get-VaultValue -Description $description -Key $key -Require:$Require
+    } catch {
+        $ErrorActionPreference = $originalErrorActionPreference
+        Write-Error $_
+    }
+}
+
+<#
+.SYNOPSIS
+Gets a secure file name.
+
+.DESCRIPTION
+Gets the name for a secure file.
+
+.PARAMETER Id
+Secure file id.
+
+.PARAMETER Require
+Writes an error to the error pipeline if the ticket is not found.
+#>
+function Get-SecureFileName {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Id,
+        [switch]$Require)
+
+    $originalErrorActionPreference = $ErrorActionPreference
+    try {
+        $ErrorActionPreference = 'Stop'
+
+        $description = Get-LocString -Key PSLIB_Input0 -ArgumentList $Id
+        $key = "SECUREFILE_NAME_$Id"
+        
+        Get-VaultValue -Description $description -Key $key -Require:$Require
+    } catch {
+        $ErrorActionPreference = $originalErrorActionPreference
+        Write-Error $_
+    }
+}
+
+<#
+.SYNOPSIS
 Gets an input.
 
 .DESCRIPTION

--- a/powershell/VstsTaskSdk/VstsTaskSdk.psm1
+++ b/powershell/VstsTaskSdk/VstsTaskSdk.psm1
@@ -38,6 +38,8 @@ Export-ModuleMember -Function @(
         'Select-Match'
         # Input functions.
         'Get-Endpoint'
+        'Get-SecureFileTicket'
+        'Get-SecureFileName'
         'Get-Input'
         'Get-TaskVariable'
         'Get-TaskVariableInfo'


### PR DESCRIPTION
Added two new input functions in PS SDK Get-VstsSecureFileName and Get-VstsSecureFileTicket to match the available operations in Node SDK. For each new cmdlet, there is also a test associated.