### PR TITLE
Fixed issues with $env:TMP in PS Tests

### DIFF
--- a/powershell/Tests/L0/Assert-Path.DoesNotThrowWhenPathExists.ps1
+++ b/powershell/Tests/L0/Assert-Path.DoesNotThrowWhenPathExists.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         $directory = (New-Item -Path $tempDirectory\SomeDir -ItemType Directory).FullName

--- a/powershell/Tests/L0/Assert-Path.ThrowsWhenNotFound.ps1
+++ b/powershell/Tests/L0/Assert-Path.ThrowsWhenNotFound.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         $directory = New-Item -Path $tempDirectory\SomeDir -ItemType Directory

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsDirectoryNameSingleCharWildcard.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsDirectoryNameSingleCharWildcard.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsDirectoryNameWildcard.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsDirectoryNameWildcard.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsExcludePattern.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsExcludePattern.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsFileNameSingleCharWildcard.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsFileNameSingleCharWildcard.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsFileNameWildcard.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsFileNameWildcard.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsGlobstar.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsGlobstar.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsIncludeDirectories.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsIncludeDirectories.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsIncludeDirectoriesOnly.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsIncludeDirectoriesOnly.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternSupportsInterSegmentWildcard.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternSupportsInterSegmentWildcard.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Files.LegacyPatternUnionsMatches.ps1
+++ b/powershell/Tests/L0/Find-Files.LegacyPatternUnionsMatches.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.AggregatesMatches.ps1
+++ b/powershell/Tests/L0/Find-Match.AggregatesMatches.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.AppliesDefaultFindOptions.ps1
+++ b/powershell/Tests/L0/Find-Match.AppliesDefaultFindOptions.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.AppliesDefaultMatchOptions.ps1
+++ b/powershell/Tests/L0/Find-Match.AppliesDefaultMatchOptions.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.BracesNotEscaped.ps1
+++ b/powershell/Tests/L0/Find-Match.BracesNotEscaped.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.CountsLeadingNegateMarkers.ps1
+++ b/powershell/Tests/L0/Find-Match.CountsLeadingNegateMarkers.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.DefaultRootFallsBackToCwd.ps1
+++ b/powershell/Tests/L0/Find-Match.DefaultRootFallsBackToCwd.ps1
@@ -6,7 +6,7 @@ param()
 Invoke-VstsTaskScript -ScriptBlock {
     $originalSystemDefaultWorkingDirectory = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
     $originalCwd = Get-Location
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.DefaultRootFallsBackToSystemDefaultWorkingDirectory.ps1
+++ b/powershell/Tests/L0/Find-Match.DefaultRootFallsBackToSystemDefaultWorkingDirectory.ps1
@@ -5,7 +5,7 @@ param()
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
     $originalSystemDefaultWorkingDirectory = $env:SYSTEM_DEFAULTWORKINGDIRECTORY
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.DoesNotDuplicateMatches.ps1
+++ b/powershell/Tests/L0/Find-Match.DoesNotDuplicateMatches.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.EscapesDefaultRootWhenRootingPatterns.ps1
+++ b/powershell/Tests/L0/Find-Match.EscapesDefaultRootWhenRootingPatterns.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.EvaluatesCommentsBeforeExpandingBraces.ps1
+++ b/powershell/Tests/L0/Find-Match.EvaluatesCommentsBeforeExpandingBraces.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.EvaluatesCommentsBeforeNegation.ps1
+++ b/powershell/Tests/L0/Find-Match.EvaluatesCommentsBeforeNegation.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.EvaluatesNegationBeforeExpandingBraces.ps1
+++ b/powershell/Tests/L0/Find-Match.EvaluatesNegationBeforeExpandingBraces.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SinglePattern.ps1
+++ b/powershell/Tests/L0/Find-Match.SinglePattern.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SkipsEmptyPatterns.ps1
+++ b/powershell/Tests/L0/Find-Match.SkipsEmptyPatterns.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsCustomFindOptions.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsCustomFindOptions.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsFlipNegateTrue.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsFlipNegateTrue.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsInterleavedExcludePatterns.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsInterleavedExcludePatterns.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsMatchBaseExcludePatterns.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsMatchBaseExcludePatterns.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsMatchBaseIncludePatterns.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsMatchBaseIncludePatterns.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsMatchBaseIncludePatternsWithGlob.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsMatchBaseIncludePatternsWithGlob.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsNoBraceFalse.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsNoBraceFalse.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsNoCommentTrue.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsNoCommentTrue.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.SupportsNoNegateTrue.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsNoNegateTrue.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.TrimsPatterns.ps1
+++ b/powershell/Tests/L0/Find-Match.TrimsPatterns.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Find-Match.TrimsWhitespaceAfterNegateMarkers.ps1
+++ b/powershell/Tests/L0/Find-Match.TrimsWhitespaceAfterNegateMarkers.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.DoesNotFollowSpecifiedSymlink.ps1
+++ b/powershell/Tests/L0/Get-FindResult.DoesNotFollowSpecifiedSymlink.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.DoesNotFollowSymlink.ps1
+++ b/powershell/Tests/L0/Get-FindResult.DoesNotFollowSymlink.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.DoesNotFollowSymlinkWhen-H.ps1
+++ b/powershell/Tests/L0/Get-FindResult.DoesNotFollowSymlinkWhen-H.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.FollowsSpecifiedSymlinkWhen-H.ps1
+++ b/powershell/Tests/L0/Get-FindResult.FollowsSpecifiedSymlinkWhen-H.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.FollowsSpecifiedSymlinkWhen-L.ps1
+++ b/powershell/Tests/L0/Get-FindResult.FollowsSpecifiedSymlinkWhen-L.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.FollowsSymlinkWhen-L.ps1
+++ b/powershell/Tests/L0/Get-FindResult.FollowsSymlinkWhen-L.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.ReturnsEmptyWhenNotExists.ps1
+++ b/powershell/Tests/L0/Get-FindResult.ReturnsEmptyWhenNotExists.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-FindResult.ReturnsHiddenFiles.ps1
+++ b/powershell/Tests/L0/Get-FindResult.ReturnsHiddenFiles.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {

--- a/powershell/Tests/L0/Get-LocString.HandlesDotNetFormatException.ps1
+++ b/powershell/Tests/L0/Get-LocString.HandlesDotNetFormatException.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         New-Item -Path $tempDirectory\my.json -ItemType File -Value @'

--- a/powershell/Tests/L0/Get-LocString.OverlaysWithCultureSpecific.ps1
+++ b/powershell/Tests/L0/Get-LocString.OverlaysWithCultureSpecific.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         New-Item -Path $tempDirectory\my.json -ItemType File -Value @'

--- a/powershell/Tests/L0/Get-LocString.SupportsDotNetFormatStrings.ps1
+++ b/powershell/Tests/L0/Get-LocString.SupportsDotNetFormatStrings.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         New-Item -Path $tempDirectory\my.json -ItemType File -Value @'

--- a/powershell/Tests/L0/Invoke-Tool.SupportsOutputEncoding.ps1
+++ b/powershell/Tests/L0/Invoke-Tool.SupportsOutputEncoding.ps1
@@ -4,7 +4,7 @@ param()
 # Arrange.
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         set-Content -LiteralPath $tempDirectory\Program.cs -Value @"

--- a/powershell/Tests/L0/Invoke-Tool.SupportsWorkingDirectory.ps1
+++ b/powershell/Tests/L0/Invoke-Tool.SupportsWorkingDirectory.ps1
@@ -5,13 +5,13 @@ param()
 . $PSScriptRoot\..\lib\Initialize-Test.ps1
 Invoke-VstsTaskScript -ScriptBlock {
     $originalLocation = $PWD
-    $tempDirectory = [System.IO.Path]::Combine($env:TMP, [System.IO.Path]::GetRandomFileName())
+    $tempDirectory = [System.IO.Path]::Combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
     New-Item -Path $tempDirectory -ItemType Directory | ForEach-Object { $_.FullName }
     try {
         Set-Location $env:TMP
         $variableSets = @(
-            @{ Expected = $env:TMP ; Splat = @{ } }
-            @{ Expected = $env:TMP ; Splat = @{ WorkingDirectory = $env:TMP } }
+            @{ Expected = [System.IO.Path]::GetTempPath().TrimEnd('\') ; Splat = @{ } }
+            @{ Expected = [System.IO.Path]::GetTempPath().TrimEnd('\') ; Splat = @{ WorkingDirectory = [System.IO.Path]::GetTempPath() } }
             @{ Expected = $tempDirectory ; Splat = @{ WorkingDirectory = $tempDirectory } }
         )
         foreach ($variableSet in $variableSets) {
@@ -22,7 +22,7 @@ Invoke-VstsTaskScript -ScriptBlock {
 
             # Assert.
             Assert-AreEqual $variableSet.Expected $actual
-            Assert-AreEqual $env:TMP (Get-Location).Path
+            Assert-AreEqual ([System.IO.Path]::GetTempPath().TrimEnd('\')) (Get-Location).Path
         }
     } finally {
         Set-Location $originalLocation


### PR DESCRIPTION
Using $env:TMP in some cases can result in a short path file name which fails several tests. By using [System.IO.Path]::GetTempPath() instead, we can solve this issue.
Closes #357