### PR TITLE
Added quotes around test tooling invocation

### DIFF
--- a/powershell/make.js
+++ b/powershell/make.js
@@ -66,10 +66,10 @@ target.test = function() {
     target.build();
 
     util.mkdir('-p', testPath);
-    util.run(`tsc --outDir ${testPath} --module commonjs --rootDir Tests Tests/lib/psRunner.ts`);
-    util.run(`tsc --outDir ${testPath} --rootDir Tests Tests/L0/_suite.ts`);
+    util.run(`tsc --outDir "${testPath}" --module commonjs --rootDir Tests Tests/lib/psRunner.ts`);
+    util.run(`tsc --outDir "${testPath}" --rootDir Tests Tests/L0/_suite.ts`);
     util.cp('-r', path.join('Tests', '*'), testPath);
-    util.run('mocha ' + path.join(testPath, 'L0', '_suite.js'));
+    util.run('mocha "' + path.join(testPath, 'L0', '_suite.js') + '"');
 }
 
 target.loc = function() {


### PR DESCRIPTION
In case your ${testPath} contains a space, running tests with the attached script, will fail.
Fix is quite trivial and save some annoiances.

Closes #359 