### PR TITLE
Find-Match in powershell does not support searching a pattern in a path that does not exist

### DIFF
--- a/node/test/findmatchtests.ts
+++ b/node/test/findmatchtests.ts
@@ -75,6 +75,22 @@ describe('Find and Match Tests', function () {
         done();
     });
 
+    it('supports path not found', (done: MochaDone) => {
+        this.timeout(1000);
+
+        let root: string = path.join(testutil.getTestTemp(), 'find-and-match_supports-path-not-found');
+        tl.mkdirP(root);
+        let patterns: string[] = [
+            path.join(root, 'NotFound', '*.proj'),
+        ];
+
+        let actual: string[] = tl.findMatch('', patterns);
+        let expected: string[] = [];
+        assert.deepEqual(actual, expected);
+
+        done();
+    });
+
     it('does not duplicate matches', (done: MochaDone) => {
         this.timeout(1000);
 

--- a/powershell/Tests/L0/Find-Match.SupportsPathNotFound.ps1
+++ b/powershell/Tests/L0/Find-Match.SupportsPathNotFound.ps1
@@ -8,13 +8,15 @@ Invoke-VstsTaskScript -ScriptBlock {
     New-Item -Path $tempDirectory -ItemType Directory |
         ForEach-Object { $_.FullName }
     try {
+        $patterns = "$tempDirectory\NotFound\*.proj"
+
         # Act.
-        $actual = & (Get-Module VstsTaskSdk) Get-FindResult -Path "$tempDirectory\nosuch" -Options (New-VstsFindOptions)
+        $actual = Find-VstsMatch -Pattern $patterns
 
         # Assert.
-        $expected = @( )
+        $expected = $null
         Assert-AreEqual $expected $actual
     } finally {
-        Remove-Item $tempDirectory -Recurse -Force
+        Remove-Item $tempDirectory -Recurse
     }
 }

--- a/powershell/Tests/L0/Get-FindResult.ReturnsEmptyWhenNotExists.ps1
+++ b/powershell/Tests/L0/Get-FindResult.ReturnsEmptyWhenNotExists.ps1
@@ -12,7 +12,7 @@ Invoke-VstsTaskScript -ScriptBlock {
         $actual = & (Get-Module VstsTaskSdk) Get-FindResult -Path "$tempDirectory\nosuch" -Options (New-VstsFindOptions)
 
         # Assert.
-        $expected = @( )
+        $expected = $null
         Assert-AreEqual $expected $actual
     } finally {
         Remove-Item $tempDirectory -Recurse -Force

--- a/powershell/VstsTaskSdk/FindFunctions.ps1
+++ b/powershell/VstsTaskSdk/FindFunctions.ps1
@@ -155,7 +155,7 @@ function Find-Match {
                             $findResults += $findPath
                         }
                     } else {
-                        $findResults = Get-FindResult -Path $findPath -Options $FindOptions
+                        $findResults = @( Get-FindResult -Path $findPath -Options $FindOptions )
                     }
 
                     Write-Verbose "Found $($findResults.Count) paths."
@@ -625,7 +625,7 @@ function Get-FindResult {
 
     if (!(Test-Path -LiteralPath $Path)) {
         Write-Verbose 'Path not found.'
-        return ,@( )
+        return
     }
 
     $Path = ConvertTo-NormalizedSeparators -Path $Path

--- a/powershell/VstsTaskSdk/FindFunctions.ps1
+++ b/powershell/VstsTaskSdk/FindFunctions.ps1
@@ -625,7 +625,7 @@ function Get-FindResult {
 
     if (!(Test-Path -LiteralPath $Path)) {
         Write-Verbose 'Path not found.'
-        return
+        return ,@( )
     }
 
     $Path = ConvertTo-NormalizedSeparators -Path $Path


### PR DESCRIPTION
The fix I propose here intends to get the same behavior than when using ts `findMatch` function. To illustrate that, I added a unit test in both ts and ps.

More precisely, I pinpoint the difference between ts and ps here: https://github.com/Microsoft/vsts-task-lib/blob/master/node/task.ts#L751.